### PR TITLE
Update requirements.txt

### DIFF
--- a/apps/suggestions/requirements/requirements.txt
+++ b/apps/suggestions/requirements/requirements.txt
@@ -5,3 +5,4 @@ opentelemetry-api==1.11.1
 opentelemetry-sdk==1.11.1
 opentelemetry-exporter-otlp-proto-grpc==1.11.1
 protobuf~=3.20.0
+Werkzeug==2.2.2

--- a/jaeger/docker-compose.yaml
+++ b/jaeger/docker-compose.yaml
@@ -4,7 +4,8 @@ services:
   jaeger:
     image: jaegertracing/opentelemetry-all-in-one:latest
     ports:
-      - "16686:16686" # api
+      - "16685:16685" # grpc server for jaeger-query service
+      - "16686:16686" # http server for Jaeger-query UI
       - "4317:4317" # grpc
 
 networks:


### PR DESCRIPTION
I got the following error while running the repo
```
from werkzeug.urls import url_quote
E   ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/opt/conda/lib/python3.10/site-packages/werkzeug/urls.py)
``` 
According to the [post](https://stackoverflow.com/questions/77213053/importerror-cannot-import-name-url-quote-from-werkzeug-urls). The error can be fixed by precising the version of Werkzeug